### PR TITLE
Moving queryParams

### DIFF
--- a/request.go
+++ b/request.go
@@ -43,6 +43,7 @@ func NewRequest(ctx *fasthttp.RequestCtx) *Request {
 	req.queryParams = make(map[string]string)
 	req.BaseUrl = string(ctx.URI().Path())
 	req.Writer = ctx.Response.BodyWriter()
+	req.buildQueryParams()
 
 	return req
 }

--- a/route.go
+++ b/route.go
@@ -10,6 +10,5 @@ type Route struct {
 // call builds the route params & executes the function tied to the route
 func (r *Route) call(req *Request) {
 	req.buildRouteParams(r.route)
-	req.buildQueryParams()
 	r.routeFunc(req)
 }


### PR DESCRIPTION
Moving the creation of the queryParams map to when the new request object is created so it can be used in the middleware.